### PR TITLE
Add support for conceded values 3 and 4

### DIFF
--- a/app/sdk/model/Player.scala
+++ b/app/sdk/model/Player.scala
@@ -43,7 +43,7 @@ case class PlayerTechLevel(
 
 object PlayerConcededResult extends Enumeration {
   type ConcededResult = Value
-  val active, awayFromKeyboard, quit = Value
+  val active, awayFromKeyboard, quit, ko, bot = Value
 
   implicit val fmt: Format[ConcededResult] = new Format[ConcededResult] {
     def reads(json: JsValue): JsResult[ConcededResult] = Try(PlayerConcededResult.withName(json.as[String])) match {

--- a/app/sdk/responseParsers/FullUniverseReportParsers.scala
+++ b/app/sdk/responseParsers/FullUniverseReportParsers.scala
@@ -131,6 +131,8 @@ object FullUniverseReportParsers extends ResponseParsers {
           case 0 => PlayerConcededResult.active
           case 1 => PlayerConcededResult.quit
           case 2 => PlayerConcededResult.awayFromKeyboard
+          case 3 => PlayerCondededResult.ko
+          case 4 => PlayerConcededResult.bot
         },
         ready = (jsonPlayer \ "ready").as[Int] != 0,
         missedTurns = (jsonPlayer \ "missed_turns").as[Int],


### PR DESCRIPTION
`conceded = 3` is when a player has been knocked out of the game
`conceded = 4` is when the slot was empty and the game was force started -- an AI from the very beginning